### PR TITLE
Fixes non existing objectives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/SCORMAdapter.ts
+++ b/src/SCORMAdapter.ts
@@ -10,36 +10,28 @@ export class SCORMAdapter {
   private _lastRequest: { method: "get" | "set"; key: string } | null;
   private _ignorableErrorCodes: {
     code: number;
-    shouldBeIgnored: boolean;
+    getShouldBeIgnored: () => boolean;
   }[] = [
-    { code: 0, shouldBeIgnored: true },
+    { code: 0, getShouldBeIgnored: () => true },
     {
       code: 403,
-      get shouldBeIgnored() {
-        return this._isSCORM2004;
-      },
+      getShouldBeIgnored: () => this._isSCORM2004,
     },
     {
       code: 401,
-      get shouldBeIgnored() {
-        return (
-          !this._isSCORM2004 &&
-          this._lastRequest &&
-          this._lastRequest.method === "get" &&
-          this._lastRequest.key === "cmi.objectives._children"
-        );
-      },
+      getShouldBeIgnored: () =>
+        !this._isSCORM2004 &&
+        this._lastRequest &&
+        this._lastRequest.method === "get" &&
+        this._lastRequest.key === "cmi.objectives._children",
     },
     {
       code: 402,
-      get shouldBeIgnored() {
-        return (
-          this._isSCORM2004 &&
-          this._lastRequest &&
-          this._lastRequest.method === "get" &&
-          this._lastRequest.key === "cmi.objectives._children"
-        );
-      },
+      getShouldBeIgnored: () =>
+        this._isSCORM2004 &&
+        this._lastRequest &&
+        this._lastRequest.method === "get" &&
+        this._lastRequest.key === "cmi.objectives._children",
     },
   ];
 
@@ -143,7 +135,8 @@ export class SCORMAdapter {
     const lastErrorDiagnostic = this.LMSGetDiagnostic(lastErrorCode);
     if (
       !this._ignorableErrorCodes.some(
-        ({ code, shouldBeIgnored }) => code === lastErrorCode && shouldBeIgnored
+        ({ code, getShouldBeIgnored }) =>
+          code === lastErrorCode && getShouldBeIgnored()
       )
     ) {
       console.warn(

--- a/src/SCORMAdapter.ts
+++ b/src/SCORMAdapter.ts
@@ -275,7 +275,8 @@ export class SCORMAdapter {
   }
 
   get objectivesAreAvailable() {
-    return this.LMSGetValue("cmi.objectives._children") !== null;
+    const objectivesFields = !!this.LMSGetValue("cmi.objectives._children");
+    return objectivesFields && this.LMSGetLastError() === 0;
   }
 
   setObjectives(objectivesIds: string[]) {


### PR DESCRIPTION
On affichait le carré rouge avec la description de l'erreur quand on essayait d'accéder aux objectifs et qu'ils n'étaient pas disponibles sur le lms, ce qui est normal puisque pour avoir le retour de `objectivesAreAvailable` on est obligés d'essayer d'y accéder.

Donc j'ai ajouté dans la liste des erreurs à ignorer les code 401 (en scorm 1.2) et 402 (en scorm 2004) qui correspondent à une clé non implémentée dans le lms lorsque la commande précédente était le get sur objectivesAreAvailable