### PR TITLE
Put back duration calculation on scol-r and use correct format

### DIFF
--- a/src/loadContent.js
+++ b/src/loadContent.js
@@ -147,7 +147,13 @@ function loadContent() {
   var sourceOrigin = sourceUrlParser.protocol + "//" + host;
   new MessageReceiver(window, sourceOrigin, ADAPTER);
 
+
+  var sessionStart = new Date().getTime();
+
   window.addEventListener("beforeunload", function (e) {
+    var sessionEnd = new Date().getTime();
+    ADAPTER.setSessionTime(sessionEnd - sessionStart);
+
     ADAPTER.LMSTerminate();
   });
 }


### PR DESCRIPTION

We need to calculate the duration of the session and send it with the correct format.
