### PR TITLE
Removes data_from_lms retrieval as we dont use it directly and it induce an issue on rise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/SCORMAdapter.ts
+++ b/src/SCORMAdapter.ts
@@ -136,8 +136,12 @@ export class SCORMAdapter {
     } else if (!this._isSCORM2004 && !(fun.indexOf("LMS") == 0)) {
       fun = "LMS" + fun;
     }
-    console.info("[SCOL-R] Calling a scorm api function", { fun, args });
-    return this._API[fun].apply(this._API, args);
+
+    const result = this._API[fun].apply(this._API, args);
+    console.info(
+      `[SCOL-R] ${fun}(${args.join(", ")}) = ${JSON.stringify(result)}`
+    );
+    return result;
   }
 
   private _handleError(functionName: string) {

--- a/src/loadContent.js
+++ b/src/loadContent.js
@@ -58,7 +58,7 @@ export function loadContent() {
   document.getElementById("footer-content").innerHTML =
     localizeMessage("pageFooter");
   document.getElementById("title-error-messages").innerHTML = localizeMessage(
-    "pageErrorMessagesTitle",
+    "pageErrorMessagesTitle"
   );
 
   var displayInitError = function (message) {
@@ -125,8 +125,7 @@ export function loadContent() {
     "scorm" +
     `&learner_id=${learnerId}` +
     `&learner_name=${learnerName}` +
-    `&lms_origin=${encodeURIComponent(location.origin)}` +
-    `&data_from_lms=${ADAPTER.getDataFromLMS()}`;
+    `&lms_origin=${encodeURIComponent(location.origin)}`;
 
   var iframe = document.createElement("iframe");
   iframe.setAttribute("src", sourceUrlParser.href);

--- a/src/loadContent.test.ts
+++ b/src/loadContent.test.ts
@@ -121,7 +121,7 @@ describe("loadContent", () => {
 
     const iframeSrc = iframe?.getAttribute("src");
     expect(iframeSrc).toBe(
-      "https://www.example.com/?scorm&learner_id=JohnDoeID&learner_name=John%20Doe&lms_origin=http%3A%2F%2Flocalhost&data_from_lms={%22lms_origin%22:%22http://localhost%22}"
+      "https://www.example.com/?scorm&learner_id=JohnDoeID&learner_name=John%20Doe&lms_origin=http%3A%2F%2Flocalhost"
     );
   });
 
@@ -139,7 +139,7 @@ describe("loadContent", () => {
 
     const iframeSrc = iframe?.getAttribute("src");
     expect(iframeSrc).toBe(
-      "https://www.example.com/?scorm&learner_id=JohnDoeID&learner_name=John%20Doe&lms_origin=http%3A%2F%2Flocalhost&data_from_lms={%22lms_origin%22:%22http://localhost%22}"
+      "https://www.example.com/?scorm&learner_id=JohnDoeID&learner_name=John%20Doe&lms_origin=http%3A%2F%2Flocalhost"
     );
   });
 });


### PR DESCRIPTION
We have an error message on rise. It's caused by a call on launch_data, I don't know why but it don't work on rise. By chance we don't use this value
