### PR TITLE
SUPPORT-1259 Make sure scorm connect setLessonStatus always commit after lesson status change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.9.0",
+  "version": "2.10.1",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/MessageHandler.ts
+++ b/src/MessageHandler.ts
@@ -2,7 +2,7 @@ export class MessageReceiver {
   constructor(
     win: Window,
     sourceOrigin: string,
-    private readonly adapter: any
+    private readonly adapter: any,
   ) {
     let timeoutId: NodeJS.Timeout | null = null;
 
@@ -27,7 +27,7 @@ export class MessageReceiver {
             timeoutId = null;
           }, 500);
         }
-      }.bind(this)
+      }.bind(this),
     );
   }
 
@@ -49,6 +49,7 @@ export class MessageReceiver {
 
   setLessonStatus(lessonStatus: string) {
     this.adapter.setLessonStatus(lessonStatus);
+    this.adapter.commit(); // We commit the changes to the LMS each time the lesson status is updated.
   }
 
   setObjectives(objectivesIds: string[]) {
@@ -81,14 +82,14 @@ export class MessageEmitter {
 
   private sendMessage(
     name: string,
-    values: (string[] | string | number)[]
+    values: (string[] | string | number)[],
   ): void {
     this.currentWindow.postMessage(
       {
         function: name,
         arguments: values,
       },
-      this.lmsOrigin
+      this.lmsOrigin,
     );
   }
 
@@ -109,7 +110,7 @@ export class MessageEmitter {
   }
   setObjectiveStatus(
     objectiveId: string,
-    status: "completed" | "incomplete"
+    status: "completed" | "incomplete",
   ): void {
     this.sendMessage("setObjectiveStatus", [objectiveId, status]);
   }


### PR DESCRIPTION
[Contributing Guidelines](https://github.com/Didask/odc#contributing)

# ❓Problem

Sometimes scorm connect users close badly the LMS tab and changes are not committed (progression not saved to the LMS).

# 🎯 Solution

In scorm connect, force commit each time lesson status is set.
We also want to be sure the score is set before the status to make sure the last score is committed.

# 🧭 Tests

- [x] Test with scorm cloud

# 🧑‍🎓 Checklist

- [x] I have reviewed my own PR