### PR TITLE
ODC-9669 - Fix the 2004 manifest shape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/ManifestGenerator.test.ts
+++ b/src/ManifestGenerator.test.ts
@@ -1,0 +1,70 @@
+import { ManifestGenerator, Sco } from "./ManifestGenerator";
+
+const baseProps = {
+  courseId: "course123",
+  courseTitle: "Animer ses cours",
+  courseAuthor: "Sciconum",
+  scoList: [
+    new Sco({
+      scoID: "sco123",
+      scoTitle: "Animer ses cours",
+      author: "Sciconum",
+      learningTime: 120,
+      scoHref: "./sco123/index.html",
+      resources: ["./sco123/index.html"],
+    }),
+  ],
+  sharedResources: ["./lib/SCORMAdapter.js"],
+};
+
+describe("ManifestGenerator — SCORM 2004", () => {
+  const manifest = ManifestGenerator({
+    ...baseProps,
+    scormVersion: "2004 4th Edition",
+  });
+
+  test("uses the 2004 namespaces, not the 1.2 ones", () => {
+    expect(manifest).toContain(
+      'xmlns="http://www.imsglobal.org/xsd/imscp_v1p1"'
+    );
+    expect(manifest).toContain(
+      'xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_v1p3"'
+    );
+    expect(manifest).toContain('xmlns:imsss="http://www.imsglobal.org/xsd/imsss"');
+    expect(manifest).not.toContain("imscp_rootv1p1p2");
+    expect(manifest).not.toContain("adlcp_rootv1p2");
+    expect(manifest).not.toContain("ADL SCORM 1.2");
+  });
+
+  test("declares no measure-based satisfaction by default (status governs)", () => {
+    expect(manifest).not.toContain("<imsss:sequencing>");
+    expect(manifest).not.toContain("satisfiedByMeasure");
+    expect(manifest).not.toContain("minNormalizedMeasure");
+  });
+
+  test("emits the 2004-cased scormType on resources", () => {
+    expect(manifest).toContain('adlcp:scormType="sco"');
+    expect(manifest).not.toContain("adlcp:scormtype");
+  });
+
+  test("keeps the declared schemaversion", () => {
+    expect(manifest).toContain("<schemaversion>2004 4th Edition</schemaversion>");
+  });
+});
+
+describe("ManifestGenerator — SCORM 1.2", () => {
+  test("still emits the 1.2 structure and no sequencing", () => {
+    const manifest = ManifestGenerator({ ...baseProps, scormVersion: "1.2" });
+    expect(manifest).toContain("imscp_rootv1p1p2");
+    expect(manifest).toContain('adlcp:scormtype="sco"');
+    expect(manifest).toContain("<schemaversion>1.2</schemaversion>");
+    expect(manifest).not.toContain("imsss");
+    expect(manifest).not.toContain("minNormalizedMeasure");
+  });
+
+  test("defaults to 1.2 when no version is given", () => {
+    const manifest = ManifestGenerator(baseProps);
+    expect(manifest).toContain("<schemaversion>1.2</schemaversion>");
+    expect(manifest).not.toContain("imsss");
+  });
+});

--- a/src/ManifestGenerator.ts
+++ b/src/ManifestGenerator.ts
@@ -68,6 +68,19 @@ export function ManifestGenerator({
     ? scoList.reduce((acc, sco) => acc + sco.learningTime, 0)
     : totalLearningTime;
 
+  if (scormVersion.startsWith("2004")) {
+    return generate2004Manifest({
+      courseId,
+      courseTitle: courseTitle ?? "",
+      courseAuthor: courseAuthor ?? "",
+      scoList,
+      sharedResources,
+      courseGlobalLearningTime,
+      dataFromLms,
+      scormVersion,
+    });
+  }
+
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <manifest xmlns="http://www.imsproject.org/xsd/imscp_rootv1p1p2" identifier="${courseId}" version="1.0" xmlns:imsmd="http://www.imsglobal.org/xsd/imsmd_rootv1p2p1" xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_rootv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsproject.org/xsd/imscp_rootv1p1p2 imscp_rootv1p1p2.xsd http://www.imsglobal.org/xsd/imsmd_rootv1p2p1 imsmd_rootv1p2p1.xsd http://www.adlnet.org/xsd/adlcp_rootv1p2 adlcp_rootv1p2.xsd">
       <metadata>
@@ -192,6 +205,114 @@ export function ManifestGenerator({
       ${scoList
         .map((sco) => {
           return `<resource adlcp:scormtype="sco" type="webcontent" identifier="resource_${
+            sco.scoID
+          }" href="${sco.scoHref}">
+            ${
+              sharedResources?.length
+                ? '<dependency identifierref="shared_resources"/>'
+                : ""
+            }
+            ${sco.resources
+              .map((resource) => `<file href="${resource}"/>`)
+              .join("\n")}
+          </resource>`;
+        })
+        .join("\n")}
+      </resources>
+    </manifest>`;
+}
+
+function generate2004Manifest({
+  courseId,
+  courseTitle,
+  courseAuthor,
+  scoList,
+  sharedResources,
+  courseGlobalLearningTime,
+  dataFromLms,
+  scormVersion,
+}: {
+  courseId: string;
+  courseTitle: string;
+  courseAuthor: string;
+  scoList: Sco[];
+  sharedResources: string[];
+  courseGlobalLearningTime: number;
+  dataFromLms?: string;
+  scormVersion: (typeof scormVersions)[number];
+}) {
+  // No measure-based satisfaction is declared, so the LMS uses the
+  // success_status we report verbatim (unknown on open/partial, passed/failed
+  // only when we decide) rather than inferring pass/fail from the score.
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" identifier="${courseId}" version="1" xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_v1p3" xmlns:adlseq="http://www.adlnet.org/xsd/adlseq_v1p3" xmlns:adlnav="http://www.adlnet.org/xsd/adlnav_v1p3" xmlns:imsss="http://www.imsglobal.org/xsd/imsss" xmlns:imsmd="http://ltsc.ieee.org/xsd/LOM" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imscp_v1p1 imscp_v1p1.xsd http://www.adlnet.org/xsd/adlcp_v1p3 adlcp_v1p3.xsd http://www.adlnet.org/xsd/adlseq_v1p3 adlseq_v1p3.xsd http://www.adlnet.org/xsd/adlnav_v1p3 adlnav_v1p3.xsd http://www.imsglobal.org/xsd/imsss imsss_v1p0.xsd http://ltsc.ieee.org/xsd/LOM lomLoose.xsd">
+      <metadata>
+        <schema>ADL SCORM</schema>
+        <schemaversion>${scormVersion}</schemaversion>
+        <imsmd:lom>
+          <imsmd:general>
+            <imsmd:identifier>${courseId}</imsmd:identifier>
+            <imsmd:title>
+              <imsmd:langstring xml:lang="fr">${courseTitle}</imsmd:langstring>
+            </imsmd:title>
+          </imsmd:general>
+          <imsmd:lifecycle>
+            <imsmd:contribute>
+              <imsmd:role>
+                <imsmd:source>
+                  <imsmd:langstring xml:lang="fr">LOMv1.0</imsmd:langstring>
+                </imsmd:source>
+                <imsmd:value>
+                  <imsmd:langstring xml:lang="fr">Author</imsmd:langstring>
+                </imsmd:value>
+              </imsmd:role>
+              <imsmd:centity>
+                <imsmd:vcard>
+                  begin:vcard
+                  fn:${courseAuthor}
+                  end:vcard
+                </imsmd:vcard>
+              </imsmd:centity>
+            </imsmd:contribute>
+          </imsmd:lifecycle>
+          <imsmd:educational>
+            <imsmd:typicallearningtime>
+              <imsmd:datetime>${formatLearningTime(
+                courseGlobalLearningTime
+              )}</imsmd:datetime>
+            </imsmd:typicallearningtime>
+          </imsmd:educational>
+        </imsmd:lom>
+      </metadata>
+      <organizations default="Org1">
+        <organization identifier="Org1">
+          <title>${courseTitle}</title>
+          ${scoList
+            .map(({ scoID, learningTime, resources, scoHref, ...props }) => {
+              const { scoTitle } = removeSpecialChars<Partial<Sco>>(props);
+              return `<item identifier="item_${scoID}" identifierref="resource_${scoID}" isvisible="true">
+                <title>${scoTitle}</title>
+                <adlcp:dataFromLMS>${
+                  dataFromLms ?? courseId + ":" + scoID
+                }</adlcp:dataFromLMS>
+              </item>`;
+            })
+            .join("\n")}
+        </organization>
+      </organizations>
+      <resources>
+      ${
+        sharedResources?.length
+          ? `<resource adlcp:scormType="asset" type="webcontent" identifier="shared_resources">
+            ${sharedResources
+              .map((resource) => `<file href="${resource}"/>`)
+              .join("\n")}
+          </resource>`
+          : ""
+      }
+      ${scoList
+        .map((sco) => {
+          return `<resource adlcp:scormType="sco" type="webcontent" identifier="resource_${
             sco.scoID
           }" href="${sco.scoHref}">
             ${


### PR DESCRIPTION
## Problem

A SCORM 2004 course shows **Success: Passed** on open (Completion: Incomplete, Score: 0%). In 2004, unless we declare `satisfiedByMeasure="true"`, the LMS should trust only the `success_status` we send (`unknown` until we decide). But `ManifestGenerator` emitted a **malformed 2004 manifest** — `schemaversion 2004` with 1.2 namespaces and no `imsss`. The LMS fell back to its own default, ignored our `unknown`, and (since we also report `score.scaled = 0`) rolled it up to **Passed**.

## Fix

`ManifestGenerator` now branches on `scormVersion`: 1.2 unchanged; 2004 emits a well-formed manifest (correct `imscp_v1p1`/`adlcp_v1p3`/`imsss` namespaces, `adlcp:scormType`, no measure-based satisfaction). The status is then governed solely by the `success_status` we send.

## Changes

- `src/ManifestGenerator.ts` — version branch + 2004 generator
- `src/ManifestGenerator.test.ts` — new coverage
- `package.json` — `2.17.1` → `2.17.2`

## Testing

`yarn test` (15 ✓) and `yarn build` clean; 2004 manifest validated with `xmllint`.

Tested locally :white_check_mark:

![Screenshot 2026-06-02 at 11.23.47.png](https://app.graphite.com/user-attachments/assets/d0a8e330-e346-4835-a1bf-21f72e822620.png)