### PR TITLE
FIX - ODC-9797 - Use LMSInitialize as the condition to detect 2004 / 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/SCORMAdapter.test.ts
+++ b/src/SCORMAdapter.test.ts
@@ -1,4 +1,76 @@
-import { convertMsToCMITimespan, convertToTimeInterval } from "./SCORMAdapter";
+import {
+  convertMsToCMITimespan,
+  convertToTimeInterval,
+  SCORMAdapter,
+} from "./SCORMAdapter";
+
+describe("API discovery", () => {
+  const originalWindow = (global as any).window;
+
+  afterEach(() => {
+    (global as any).window = originalWindow;
+  });
+
+  const makeWindow = (props: Record<string, any>) => {
+    const win: any = { ...props };
+    win.parent = win; // top window: parent === self
+    return win;
+  };
+
+  const make2004API = () => ({
+    Initialize: jest.fn(() => "true"),
+    Terminate: jest.fn(() => "true"),
+    GetValue: jest.fn(() => ""),
+    SetValue: jest.fn(() => "true"),
+    Commit: jest.fn(() => "true"),
+    GetLastError: jest.fn(() => "0"),
+    GetErrorString: jest.fn(() => ""),
+    GetDiagnostic: jest.fn(() => ""),
+  });
+
+  test("ignores a stray non-1.2 window.API and selects the real 2004 runtime", () => {
+    const realAPI = make2004API();
+    // window.API exists but is NOT a valid 1.2 adapter (no LMSInitialize),
+    // mimicking Cornerstone's 2004 launch frame.
+    (global as any).window = makeWindow({
+      API: { someUnrelatedNamespace: true },
+      API_1484_11: realAPI,
+    });
+
+    const adapter = new SCORMAdapter();
+
+    expect(adapter.foundAPI).toBe(true);
+    expect(() => adapter.LMSInitialize()).not.toThrow();
+    expect(realAPI.Initialize).toHaveBeenCalled();
+  });
+
+  test("still selects a valid 1.2 API when present (no regression)", () => {
+    const api12 = {
+      LMSInitialize: jest.fn(() => "true"),
+      LMSGetLastError: jest.fn(() => "0"),
+      LMSSetValue: jest.fn(() => "true"),
+      LMSGetValue: jest.fn(() => ""),
+      LMSGetErrorString: jest.fn(() => ""),
+      LMSGetDiagnostic: jest.fn(() => ""),
+    };
+    (global as any).window = makeWindow({ API: api12 });
+
+    const adapter = new SCORMAdapter();
+    adapter.LMSInitialize();
+
+    expect(api12.LMSInitialize).toHaveBeenCalled();
+  });
+
+  test("does not throw when the selected API is missing a called function", () => {
+    const api = make2004API();
+    delete (api as any).Terminate;
+    (global as any).window = makeWindow({ API_1484_11: api });
+
+    const adapter = new SCORMAdapter();
+
+    expect(() => adapter.LMSTerminate()).not.toThrow();
+  });
+});
 
 test('convertMsToCMITimespan ("0000:00:00.00")', () => {
   const milliseconds = 36 * 60 * 60 * 1000 + 6 * 60 * 1000 + 2 * 1000 + 23 * 10;

--- a/src/SCORMAdapter.ts
+++ b/src/SCORMAdapter.ts
@@ -93,11 +93,19 @@ export class SCORMAdapter {
     }
   }
 
+  private _isValid12API(api: any): boolean {
+    return !!api && typeof api.LMSInitialize === "function";
+  }
+
+  private _isValid2004API(api: any): boolean {
+    return !!api && typeof api.Initialize === "function";
+  }
+
   private _findAPIInWindow(win: ApiWindow) {
     let findAPITries = 0;
     while (
-      win.API == null &&
-      win.API_1484_11 == null &&
+      !this._isValid12API(win.API) &&
+      !this._isValid2004API(win.API_1484_11) &&
       win.parent != null &&
       win.parent != win
     ) {
@@ -109,12 +117,12 @@ export class SCORMAdapter {
       win = win.parent as ApiWindow;
     }
 
-    if (win.API) {
+    if (this._isValid12API(win.API)) {
       return {
         API: win.API,
         isSCORM2004: false,
       };
-    } else if (win.API_1484_11) {
+    } else if (this._isValid2004API(win.API_1484_11)) {
       return {
         API: win.API_1484_11,
         isSCORM2004: true,
@@ -135,6 +143,17 @@ export class SCORMAdapter {
       fun = fun.substr(3);
     } else if (!this._isSCORM2004 && !(fun.indexOf("LMS") == 0)) {
       fun = "LMS" + fun;
+    }
+
+    if (typeof this._API[fun] !== "function") {
+      console.error(
+        `[SCOL-R] The SCORM API does not expose "${fun}". ` +
+          `The adapter selected ${
+            this._isSCORM2004 ? "a SCORM 2004" : "a SCORM 1.2"
+          } API that is missing this function.`
+      );
+      this._errorCallback("apiFunctionMissing");
+      return;
     }
 
     const result = this._API[fun].apply(this._API, args);


### PR DESCRIPTION
# 🎯 Intent

`ODC-9385`. The adapter picks the SCORM runtime by looking up the window tree for `window.API` (1.2) or `window.API_1484_11` (2004). It used to accept *any* truthy `window.API` as the 1.2 runtime.

Cornerstone launches 2004 content in a frame where `window.API` exists but isn't a real 1.2 adapter — it's an unrelated object with no `LMSInitialize`. The old check matched it, so the adapter locked onto the wrong API and every `LMS*` call failed.

This change validates the object before selecting it:
- `window.API` only counts as 1.2 if it has a `LMSInitialize` function.
- `window.API_1484_11` only counts as 2004 if it has an `Initialize` function.

```
window.API          = { someUnrelatedNamespace: true }   // not 1.2 → skipped
window.API_1484_11  = { Initialize, GetValue, ... }       // valid 2004 → selected
```

It also adds a guard in the call path: if the selected API is missing a function being called, the adapter logs an error and fires the `apiFunctionMissing` callback instead of throwing.

# ✅ Verification

Unit tests cover the three cases: a stray non-1.2 `window.API` alongside a real 2004 runtime, a valid 1.2 API (regression check), and a selected API missing a called function.

# 🤖 AI Contribution

AI level: 4/10 — AI-assisted