### PR TITLE
ODC-9965 - emit cmi.progress_measure via setProgress (SCORM 2004)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didask/scol-r",
-  "version": "2.17.3",
+  "version": "2.18.0",
   "description": "Shareable Cross-Origin Learning Resources",
   "main": "index.html",
   "types": "lib/index.d.ts",

--- a/src/MessageHandler.ts
+++ b/src/MessageHandler.ts
@@ -43,6 +43,10 @@ export class MessageReceiver {
     this.adapter.setScore(score);
   }
 
+  setProgress(measure: number) {
+    this.adapter.setProgress(measure);
+  }
+
   setStudent(studentId: string, studentName: string) {
     this.adapter.setStudent(studentId, studentName);
   }
@@ -100,6 +104,9 @@ export class MessageEmitter {
   }
   setScore(score: number): void {
     this.sendMessage("setScore", [score]);
+  }
+  setProgress(measure: number): void {
+    this.sendMessage("setProgress", [measure]);
   }
   setObjectives(objectives: string[]): void {
     this.sendMessage("setObjectives", [objectives]);

--- a/src/SCORMAdapter.test.ts
+++ b/src/SCORMAdapter.test.ts
@@ -83,3 +83,60 @@ test("convertToTimeInterval", () => {
   const timeInterval = convertToTimeInterval(milliseconds);
   expect(timeInterval).toBe("P1DT12H6M2S");
 });
+
+describe("setProgress", () => {
+  const originalWindow = (global as any).window;
+
+  afterEach(() => {
+    (global as any).window = originalWindow;
+  });
+
+  const makeWindow = (props: Record<string, any>) => {
+    const win: any = { ...props };
+    win.parent = win;
+    return win;
+  };
+
+  const make2004API = () => ({
+    Initialize: jest.fn(() => "true"),
+    Terminate: jest.fn(() => "true"),
+    GetValue: jest.fn(() => ""),
+    SetValue: jest.fn(() => "true"),
+    Commit: jest.fn(() => "true"),
+    GetLastError: jest.fn(() => "0"),
+    GetErrorString: jest.fn(() => ""),
+    GetDiagnostic: jest.fn(() => ""),
+  });
+
+  test("writes cmi.progress_measure clamped to [0,1] on SCORM 2004", () => {
+    const api = make2004API();
+    (global as any).window = makeWindow({ API_1484_11: api });
+
+    const adapter = new SCORMAdapter();
+    adapter.setProgress(0.5);
+    expect(api.SetValue).toHaveBeenCalledWith("cmi.progress_measure", 0.5);
+
+    adapter.setProgress(1.7);
+    expect(api.SetValue).toHaveBeenCalledWith("cmi.progress_measure", 1);
+  });
+
+  test("is a no-op on SCORM 1.2 (no progress_measure field)", () => {
+    const api12 = {
+      LMSInitialize: jest.fn(() => "true"),
+      LMSGetLastError: jest.fn(() => "0"),
+      LMSSetValue: jest.fn(() => "true"),
+      LMSGetValue: jest.fn(() => ""),
+      LMSGetErrorString: jest.fn(() => ""),
+      LMSGetDiagnostic: jest.fn(() => ""),
+    };
+    (global as any).window = makeWindow({ API: api12 });
+
+    const adapter = new SCORMAdapter();
+    adapter.setProgress(0.5);
+
+    expect(api12.LMSSetValue).not.toHaveBeenCalledWith(
+      "cmi.progress_measure",
+      expect.anything(),
+    );
+  });
+});

--- a/src/SCORMAdapter.ts
+++ b/src/SCORMAdapter.ts
@@ -315,6 +315,13 @@ export class SCORMAdapter {
     }
   }
 
+  setProgress(measure: number) {
+    // cmi.progress_measure is a SCORM 2004 field (real 0..1); SCORM 1.2 has no equivalent.
+    if (!this._isSCORM2004) return;
+    const clamped = Math.min(1, Math.max(0, measure));
+    this.LMSSetValue("cmi.progress_measure", clamped);
+  }
+
   getScore() {
     const CMIVariableName = this._isSCORM2004
       ? "cmi.score.raw"


### PR DESCRIPTION
## What

Adds `setProgress(measure)` end-to-end so SCORM Connect reports `cmi.progress_measure`:

- `SCORMAdapter.setProgress(measure)` → writes `cmi.progress_measure` (clamped to 0..1) on **SCORM 2004**; **SCORM 1.2 has no such field, so it is a no-op**.
- `MessageEmitter.setProgress` / `MessageReceiver.setProgress` plumbing (the Didask iframe → LMS-wrapper postMessage bridge).
- Version bump `2.17.3 → 2.18.0`.

## Why

SCORM Connect never emitted `cmi.progress_measure`. LMS progression columns that read it (e.g. Digiforma) therefore stayed at **0%** even for learners who had completed the course — while `completion_status`/`success_status`/`score` were sent correctly. This closes that gap and is SCORM-2004-correct regardless.

## Tests

`SCORMAdapter.test.ts`: writes `cmi.progress_measure` clamped to [0,1] on 2004; no-op on 1.2. Full suite: 20/20 pass.

## Rollout note

The CMI-writing half (`SCORMAdapter`) is **bundled into each generated package**, so consumers must **regenerate + re-upload** their SCORM Connect package to their LMS for this to take effect. Depends on a publish of `2.18.0`, after which `apps/web` bumps the dep (separate PR in `Didask/odc`).